### PR TITLE
NOV-6: Add CI workflow for automated version bump & release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.0.0
+commit = True
+tag = True
+
+[bumpversion:file:src/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}' 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,8 @@ dependencies = [
 novastream = "src.gui:main"
 
 [tool.setuptools.package-data]
-"src" = ["assets/icon.png"] 
+"src" = ["assets/icon.png"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["src", "src.*"] 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,5 @@ safety
 ruff
 
 # Utilities
-pipreqs 
+pipreqs
+bump2version 


### PR DESCRIPTION
Create a GitHub Actions workflow that runs bump2version on tag/release merges and publishes packages to PyPI or GitHub Releases.